### PR TITLE
Secure restaurant creation endpoint

### DIFF
--- a/src/modules/restaurant/CreateRestaurantController.ts
+++ b/src/modules/restaurant/CreateRestaurantController.ts
@@ -1,15 +1,41 @@
 import { FastifyRequest, FastifyReply } from "fastify";
-import { CreateRestautantService } from './CreateRestaurantService'
+import { CreateRestautantService } from "./CreateRestaurantService";
+import { errorResponse, internalError, badRequest } from "../../shared/utils/httpResponse";
 
-class CreateRestaurantController {
-    async handle(request: FastifyRequest, reply: FastifyReply) {
-        const { name } = request.body as { name: string }
-
-        const restaurantService = new CreateRestautantService()
-        const restaurant = await restaurantService.execute({ name });
-
-        reply.send(restaurant)
-    }
+interface LoggedUser {
+  id: string;
+  role: "WAITER" | "MANAGER" | "ADMIN";
+  restaurantId: string;
 }
 
-export { CreateRestaurantController }
+class CreateRestaurantController {
+  async handle(request: FastifyRequest, reply: FastifyReply) {
+    try {
+      const { name } = request.body as { name: string };
+
+      const user = request.user as LoggedUser | undefined;
+
+      if (!user || user.role !== "ADMIN") {
+        return reply
+          .status(403)
+          .send(errorResponse(403, "Only admins can create restaurants"));
+      }
+
+      if (!name || typeof name !== "string" || !name.trim()) {
+        return reply.status(400).send(badRequest("Name is required"));
+      }
+
+      const restaurantService = new CreateRestautantService();
+      const restaurant = await restaurantService.execute({ name });
+
+      return reply.status(201).send(restaurant);
+    } catch (error: any) {
+      console.error(error);
+      return reply
+        .status(500)
+        .send(internalError("Failed to create restaurant"));
+    }
+  }
+}
+
+export { CreateRestaurantController };

--- a/src/modules/restaurant/CreateRestaurantService.ts
+++ b/src/modules/restaurant/CreateRestaurantService.ts
@@ -1,21 +1,21 @@
 import prismaClient from "../../shared/prisma";
 
 interface CreateRestaurantProps {
-    name: string
+  name: string;
 }
 
 class CreateRestautantService {
-    async execute({ name }: CreateRestaurantProps) {
-        // todo validações
+  async execute({ name }: CreateRestaurantProps) {
+    const sanitizedName = name.trim().replace(/[<>]/g, "");
 
-        const restaurant = await prismaClient.restaurant.create({
-            data: {
-                name
-            }
-        })
+    const restaurant = await prismaClient.restaurant.create({
+      data: {
+        name: sanitizedName,
+      },
+    });
 
-        return restaurant
-    }
+    return restaurant;
+  }
 }
 
-export { CreateRestautantService }
+export { CreateRestautantService };

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -31,8 +31,14 @@ export async function routes(fastify: FastifyInstance) {
   fastify.post("/auth/register", authController.register);
   fastify.post("/auth/login", authController.login);
 
-  // Restaurant
-  fastify.post("/restaurant", restaurantController.handle);
+  // Restaurant - Protected
+  fastify.post(
+    "/restaurant",
+    { preHandler: [verifyToken] },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      return restaurantController.handle(request, reply);
+    }
+  );
 
   // Profile - Protected
   fastify.put(


### PR DESCRIPTION
## Summary
- protect restaurant creation route with JWT auth
- restrict endpoint to admin users and validate input
- sanitize restaurant name to avoid HTML injection

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689660fe3260832289536db7aa226c8e