### PR TITLE
feat: add restaurant order insights endpoint

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,17 +127,18 @@ model Order {
 }
 
 model OrderItem {
-  id          String                      @id @default(auto()) @map("_id") @db.ObjectId
-  orderId     String                      @db.ObjectId
-  productId   String                      @db.ObjectId
-  quantity    Int
-  imageUrl    String
-  observation String
-  ratingStar  Float
-  order       Order                       @relation(fields: [orderId], references: [id])
-  product     Product                     @relation(fields: [productId], references: [id])
+  id             String                        @id @default(auto()) @map("_id") @db.ObjectId
+  orderId        String                        @db.ObjectId
+  productId      String                        @db.ObjectId
+  quantity       Int
+  imageUrl       String?
+  observation    String?
+  ratingStar     Float?
+  order          Order                         @relation(fields: [orderId], references: [id])
+  product        Product                       @relation(fields: [productId], references: [id])
   customizations OrderItemCustomizationOption[]
 }
+
 
 model OrderItemCustomizationOption {
   id              String   @id @default(auto()) @map("_id") @db.ObjectId

--- a/src/modules/order/GetOrderInsightsController.ts
+++ b/src/modules/order/GetOrderInsightsController.ts
@@ -25,6 +25,7 @@ export class GetOrderInsightsController {
         response: insights
       })
     } catch (error) {
+      console.error("GetOrderInsightsController error:", error)
       return reply.status(500).send({
         statusCode: 500,
         response: null,

--- a/src/modules/order/GetOrderInsightsController.ts
+++ b/src/modules/order/GetOrderInsightsController.ts
@@ -1,0 +1,36 @@
+import { FastifyReply, FastifyRequest } from "fastify"
+import { GetOrderInsightsService } from "./GetOrderInsightsService"
+
+export class GetOrderInsightsController {
+  async handle(request: FastifyRequest, reply: FastifyReply) {
+    const { user } = request as any
+
+    if (!user || (user.role !== "ADMIN" && user.role !== "MANAGER")) {
+      return reply.status(403).send({
+        statusCode: 403,
+        response: null,
+        message: "Access denied"
+      })
+    }
+
+    const service = new GetOrderInsightsService()
+
+    try {
+      const insights = await service.execute({
+        restaurantId: user.restaurantId
+      })
+
+      return reply.status(200).send({
+        statusCode: 200,
+        response: insights
+      })
+    } catch (error) {
+      return reply.status(500).send({
+        statusCode: 500,
+        response: null,
+        message: "Failed to generate insights"
+      })
+    }
+  }
+}
+

--- a/src/modules/order/GetOrderInsightsService.ts
+++ b/src/modules/order/GetOrderInsightsService.ts
@@ -1,0 +1,42 @@
+import prisma from "../../shared/prisma"
+import OpenAI from "openai"
+
+interface GetOrderInsightsRequest {
+  restaurantId: string
+}
+
+export class GetOrderInsightsService {
+  private openai: OpenAI
+
+  constructor() {
+    this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  }
+
+  async execute({ restaurantId }: GetOrderInsightsRequest) {
+    const orders = await prisma.order.findMany({
+      where: { restaurantId },
+      include: {
+        items: {
+          include: { product: true }
+        }
+      },
+      orderBy: { orderedAt: "desc" }
+    })
+
+    const prompt =
+      "Você é um assistente especializado em analisar dados de restaurantes. " +
+      "Com base nos pedidos fornecidos, gere insights sobre tempo de espera, " +
+      "tempo de preparo, produtos mais vendidos e sugestões para aumentar o faturamento. \nPedidos:" +
+      JSON.stringify(orders)
+
+    const completion = await this.openai.chat.completions.create({
+      model: "gpt-3.5-turbo",
+      messages: [{ role: "user", content: prompt }]
+    })
+
+    const message = completion.choices[0].message?.content?.trim()
+
+    return message
+  }
+}
+

--- a/src/modules/order/GetOrderInsightsService.ts
+++ b/src/modules/order/GetOrderInsightsService.ts
@@ -9,10 +9,15 @@ export class GetOrderInsightsService {
   private openai: OpenAI
 
   constructor() {
-    this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      console.error("Missing OPENAI_API_KEY environment variable")
+    }
+    this.openai = new OpenAI({ apiKey })
   }
 
   async execute({ restaurantId }: GetOrderInsightsRequest) {
+    console.log(`Generating insights for restaurant ${restaurantId}`)
     const orders = await prisma.order.findMany({
       where: { restaurantId },
       include: {
@@ -23,20 +28,27 @@ export class GetOrderInsightsService {
       orderBy: { orderedAt: "desc" }
     })
 
+    console.log(`Fetched ${orders.length} orders`)
+
     const prompt =
       "Você é um assistente especializado em analisar dados de restaurantes. " +
       "Com base nos pedidos fornecidos, gere insights sobre tempo de espera, " +
       "tempo de preparo, produtos mais vendidos e sugestões para aumentar o faturamento. \nPedidos:" +
       JSON.stringify(orders)
 
-    const completion = await this.openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
-      messages: [{ role: "user", content: prompt }]
-    })
+    try {
+      const completion = await this.openai.chat.completions.create({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }]
+      })
 
-    const message = completion.choices[0].message?.content?.trim()
-
-    return message
+      const message = completion.choices[0].message?.content?.trim()
+      console.log("OpenAI response:", message)
+      return message
+    } catch (error) {
+      console.error("OpenAI API error:", error)
+      throw error
+    }
   }
 }
 

--- a/src/modules/order/GetOrderInsightsService.ts
+++ b/src/modules/order/GetOrderInsightsService.ts
@@ -18,17 +18,44 @@ export class GetOrderInsightsService {
 
   async execute({ restaurantId }: GetOrderInsightsRequest) {
     console.log(`Generating insights for restaurant ${restaurantId}`)
-    const orders = await prisma.order.findMany({
-      where: { restaurantId },
-      include: {
-        items: {
-          include: { product: true }
-        }
-      },
-      orderBy: { orderedAt: "desc" }
-    })
-
-    console.log(`Fetched ${orders.length} orders`)
+    let orders: any[] = []
+    try {
+      orders = await prisma.order.findMany({
+        where: { restaurantId },
+        select: {
+          id: true,
+          orderNumber: true,
+          status: true,
+          orderedAt: true,
+          preparedAt: true,
+          deliveredAt: true,
+          finishedAt: true,
+          canceledAt: true,
+          tableNumber: true,
+          waiterNumber: true,
+          totalValue: true,
+          paymentMethod: true,
+          items: {
+            select: {
+              quantity: true,
+              observation: true,
+              ratingStar: true,
+              product: {
+                select: {
+                  name: true,
+                  price: true
+                }
+              }
+            }
+          }
+        },
+        orderBy: { orderedAt: "desc" }
+      })
+      console.log(`Fetched ${orders.length} orders`)
+    } catch (error) {
+      console.error("Failed to fetch orders for insights", error)
+      throw error
+    }
 
     const prompt =
       "Você é um assistente especializado em analisar dados de restaurantes. " +

--- a/src/modules/order/GetOrdersService.ts
+++ b/src/modules/order/GetOrdersService.ts
@@ -7,25 +7,49 @@ interface GetOrdersRequest {
 
 export class GetOrdersService {
   async execute({ restaurantId, productId }: GetOrdersRequest) {
-    const orders = await prisma.order.findMany({
-      where: {
-        restaurantId,
-        items: productId ? {
-          some: { productId }
-        } : undefined
-      },
-      include: {
-        items: {
-          include: {
-            product: true
+    try {
+      const orders = await prisma.order.findMany({
+        where: {
+          restaurantId,
+          items: productId ? { some: { productId } } : undefined
+        },
+        select: {
+          id: true,
+          orderNumber: true,
+          status: true,
+          orderedAt: true,
+          preparedAt: true,
+          deliveredAt: true,
+          finishedAt: true,
+          canceledAt: true,
+          tableNumber: true,
+          waiterNumber: true,
+          totalValue: true,
+          paymentMethod: true,
+          items: {
+            select: {
+              id: true,
+              quantity: true,
+              observation: true,
+              ratingStar: true,
+              product: {
+                select: {
+                  id: true,
+                  name: true,
+                  price: true,
+                  imageUrl: true
+                }
+              }
+            }
           }
-        }
-      },
-      orderBy: {
-        orderedAt: "desc"
-      }
-    })
+        },
+        orderBy: { orderedAt: "desc" }
+      })
 
-    return orders
+      return orders
+    } catch (error) {
+      console.error("Failed to fetch orders from database", error)
+      throw error
+    }
   }
 }

--- a/src/modules/product/EditProductController.ts
+++ b/src/modules/product/EditProductController.ts
@@ -27,6 +27,8 @@ export class EditProductController {
         categoryId?: string;
         customizationGroups?: {
           name: string;
+          min: number;
+          max: number;
           options: {
             name: string;
             price: number;

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -12,6 +12,7 @@ import { EditProductController } from "../modules/product/EditProductController"
 import { CreateOrderController } from "../modules/order/CreateOrderController";
 import { GetOrdersController } from "../modules/order/GetOrdersController";
 import { EditOrderStatusController } from '../modules/order/EditOrderController'
+import { GetOrderInsightsController } from "../modules/order/GetOrderInsightsController"
 
 export async function routes(fastify: FastifyInstance) {
   const authController = new AuthController();
@@ -26,6 +27,7 @@ export async function routes(fastify: FastifyInstance) {
   const createOrderController = new CreateOrderController();
   const getOrdersController = new GetOrdersController()
   const editOrderStatusController = new EditOrderStatusController()
+  const getOrderInsightsController = new GetOrderInsightsController()
 
   // Auth
   fastify.post("/auth/register", authController.register);
@@ -100,6 +102,14 @@ export async function routes(fastify: FastifyInstance) {
     { preHandler: [verifyToken] },
     async (request: FastifyRequest, reply: FastifyReply) => {
       return editOrderStatusController.handle(request, reply)
+    }
+  )
+
+  fastify.get(
+    "/orders/insights",
+    { preHandler: [verifyToken] },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      return getOrderInsightsController.handle(request, reply)
     }
   )
 


### PR DESCRIPTION
## Summary
- integrate OpenAI to analyze restaurant orders
- expose protected `/orders/insights` endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Type '{ name: string; options: { name: string; price: number; }[]; }[] | undefined' is not assignable to type 'CustomizationGroupInput[] | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68966392b4dc8322a68525e24731d149