### PR TITLE
Include order item customizations in GET orders

### DIFF
--- a/src/modules/order/GetOrdersService.ts
+++ b/src/modules/order/GetOrdersService.ts
@@ -17,7 +17,8 @@ export class GetOrdersService {
       include: {
         items: {
           include: {
-            product: true
+            product: true,
+            customizations: true
           }
         }
       },

--- a/src/modules/order/GetOrdersService.ts
+++ b/src/modules/order/GetOrdersService.ts
@@ -17,7 +17,13 @@ export class GetOrdersService {
       include: {
         items: {
           include: {
-            product: true,
+            product: {
+              select: {
+                id: true,
+                name: true,
+                price: true,
+              },
+            },
             customizations: true
           }
         }


### PR DESCRIPTION
## Summary
- include order item customizations when listing orders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Type '{ name: string; options: { name: string; price: number; }[]; }[] | undefined' is not assignable to type 'CustomizationGroupInput[] | undefined' in EditProductController.ts:55)*

------
https://chatgpt.com/codex/tasks/task_e_689670608efc8322a60d20d29ae47942