### PR TITLE
feat: add endpoint to fetch restaurant by CNPJ

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,7 @@ datasource db {
 model Restaurant {
   id         String     @id @default(auto()) @map("_id") @db.ObjectId
   name       String
+  cnpj       String     @unique
   created_at DateTime?  @default(now())
   profiles   Profile[]
   categories Category[]

--- a/src/modules/restaurant/CreateRestaurantController.ts
+++ b/src/modules/restaurant/CreateRestaurantController.ts
@@ -11,7 +11,7 @@ interface LoggedUser {
 class CreateRestaurantController {
   async handle(request: FastifyRequest, reply: FastifyReply) {
     try {
-      const { name } = request.body as { name: string };
+      const { name, cnpj } = request.body as { name: string; cnpj: string };
 
       const user = request.user as LoggedUser | undefined;
 
@@ -25,8 +25,18 @@ class CreateRestaurantController {
         return reply.status(400).send(badRequest("Name is required"));
       }
 
+      if (!cnpj || typeof cnpj !== "string" || !cnpj.trim()) {
+        return reply.status(400).send(badRequest("CNPJ is required"));
+      }
+
+      const sanitizedCnpj = cnpj.replace(/\D/g, "");
+
+      if (sanitizedCnpj.length !== 14) {
+        return reply.status(400).send(badRequest("CNPJ must have 14 digits"));
+      }
+
       const restaurantService = new CreateRestautantService();
-      const restaurant = await restaurantService.execute({ name });
+      const restaurant = await restaurantService.execute({ name, cnpj: sanitizedCnpj });
 
       return reply.status(201).send(restaurant);
     } catch (error: any) {

--- a/src/modules/restaurant/CreateRestaurantService.ts
+++ b/src/modules/restaurant/CreateRestaurantService.ts
@@ -2,15 +2,18 @@ import prismaClient from "../../shared/prisma";
 
 interface CreateRestaurantProps {
   name: string;
+  cnpj: string;
 }
 
 class CreateRestautantService {
-  async execute({ name }: CreateRestaurantProps) {
+  async execute({ name, cnpj }: CreateRestaurantProps) {
     const sanitizedName = name.trim().replace(/[<>]/g, "");
+    const sanitizedCnpj = cnpj.replace(/\D/g, "");
 
     const restaurant = await prismaClient.restaurant.create({
       data: {
         name: sanitizedName,
+        cnpj: sanitizedCnpj,
       },
     });
 

--- a/src/modules/restaurant/GetRestaurantController.ts
+++ b/src/modules/restaurant/GetRestaurantController.ts
@@ -1,0 +1,43 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import prismaClient from "../../shared/prisma";
+import { badRequest, internalError, notFound, successResponse } from "../../shared/utils/httpResponse";
+
+interface GetRestaurantParams {
+  Params: {
+    cnpj: string;
+  };
+}
+
+export class GetRestaurantController {
+  async handle(request: FastifyRequest<GetRestaurantParams>, reply: FastifyReply) {
+    try {
+      const { cnpj } = request.params;
+
+      if (!cnpj) {
+        return reply.status(400).send(badRequest("CNPJ is required"));
+      }
+
+      const sanitizedCnpj = cnpj.replace(/\D/g, "");
+
+      if (sanitizedCnpj.length !== 14) {
+        return reply.status(400).send(badRequest("CNPJ must have 14 digits"));
+      }
+
+      const restaurant = await prismaClient.restaurant.findUnique({
+        where: { cnpj: sanitizedCnpj },
+      });
+
+      if (!restaurant) {
+        return reply.status(404).send(notFound("Restaurant not found"));
+      }
+
+      return reply.send(successResponse(restaurant));
+    } catch (err) {
+      console.error(err);
+      return reply
+        .status(500)
+        .send(internalError("Failed to fetch restaurant"));
+    }
+  }
+}
+

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -3,6 +3,7 @@ import { verifyToken } from "./utils/verifyToken";
 import { AuthController } from "../modules/auth/AuthController";
 import { ProfileController } from "../modules/profile/ProfileController";
 import { CreateRestaurantController } from "../modules/restaurant/CreateRestaurantController";
+import { GetRestaurantController } from "../modules/restaurant/GetRestaurantController";
 import { CreateCategoryController } from "../modules/category/CreateCategoryController";
 import { CreateProductController } from "../modules/product/CreateProductController";
 import { GetProductsController } from "../modules/product/GetProductsController";
@@ -19,6 +20,7 @@ export async function routes(fastify: FastifyInstance) {
   const authController = new AuthController();
   const profileController = new ProfileController();
   const restaurantController = new CreateRestaurantController();
+  const getRestaurantController = new GetRestaurantController();
   const createCategoryController = new CreateCategoryController();
   const createProductController = new CreateProductController();
   const getProductsController = new GetProductsController();
@@ -34,6 +36,15 @@ export async function routes(fastify: FastifyInstance) {
   // Auth
   fastify.post("/auth/register", authController.register);
   fastify.post("/auth/login", authController.login);
+
+  // Restaurant - Public
+  fastify.get(
+    "/restaurant/:cnpj",
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const req = request as FastifyRequest<{ Params: { cnpj: string } }>;
+      return getRestaurantController.handle(req, reply);
+    }
+  );
 
   // Restaurant - Protected
   fastify.post(


### PR DESCRIPTION
## Summary
- allow restaurants to store a unique CNPJ
- expose `GET /restaurant/:cnpj` for public access
- require CNPJ when creating restaurants

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b86ed7f3c8322b2c69cb0784ffb5f