### PR TITLE
feat: add device association endpoint

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,8 +15,19 @@ model Restaurant {
   profiles   Profile[]
   categories Category[]
   orders     Order[]
+  devices    Device[]
 
   @@map("restaurants")
+}
+
+model Device {
+  id           String     @id @default(auto()) @map("_id") @db.ObjectId
+  macAddress   String     @unique
+  restaurantId String     @db.ObjectId
+  restaurant   Restaurant @relation(fields: [restaurantId], references: [id])
+  createdAt    DateTime   @default(now())
+
+  @@map("devices")
 }
 
 enum ProfileRole {

--- a/src/modules/auth/AssociateDeviceService.ts
+++ b/src/modules/auth/AssociateDeviceService.ts
@@ -1,0 +1,49 @@
+import prismaClient from "../../shared/prisma";
+import { successResponse } from "../../shared/utils/httpResponse";
+
+interface AssociateDeviceProps {
+  macAddress: string;
+  restaurantCnpj: string;
+}
+
+export class AssociateDeviceService {
+  async execute({ macAddress, restaurantCnpj }: AssociateDeviceProps) {
+    const sanitizedCnpj = restaurantCnpj.replace(/\D/g, "");
+
+    const restaurant = await prismaClient.restaurant.findUnique({
+      where: { cnpj: sanitizedCnpj },
+    });
+
+    if (!restaurant) {
+      throw { statusCode: 404, message: "Restaurant not found" };
+    }
+
+    const existing = await prismaClient.device.findUnique({
+      where: { macAddress },
+    });
+
+    if (existing) {
+      if (existing.restaurantId === restaurant.id) {
+        return {
+          statusCode: 201,
+          response: null,
+          message: "mac address already associated to this cnpj",
+        };
+      }
+
+      throw {
+        statusCode: 402,
+        message: "mac address already associated to another cnpj",
+      };
+    }
+
+    await prismaClient.device.create({
+      data: {
+        macAddress,
+        restaurantId: restaurant.id,
+      },
+    });
+
+    return successResponse(null, "Device associated successfully");
+  }
+}

--- a/src/modules/auth/AssociateDeviceService.ts
+++ b/src/modules/auth/AssociateDeviceService.ts
@@ -24,11 +24,7 @@ export class AssociateDeviceService {
 
     if (existing) {
       if (existing.restaurantId === restaurant.id) {
-        return {
-          statusCode: 201,
-          response: null,
-          message: "mac address already associated to this cnpj",
-        };
+        return successResponse(null, "mac address already associated to this cnpj");
       }
 
       throw {

--- a/src/modules/auth/AuthController.ts
+++ b/src/modules/auth/AuthController.ts
@@ -1,6 +1,7 @@
 import { FastifyRequest, FastifyReply } from "fastify";
 import { RegisterUserService } from "./RegisterUserService";
 import { LoginUserService } from "./LoginUserService";
+import { AssociateDeviceService } from "./AssociateDeviceService";
 
 class AuthController {
   async register(request: FastifyRequest, reply: FastifyReply) {
@@ -26,6 +27,23 @@ class AuthController {
 
       const service = new LoginUserService();
       const result = await service.execute({ email, password });
+
+      reply.status(result.statusCode).send(result);
+    } catch (error: any) {
+      reply.status(error.statusCode || 500).send({
+        statusCode: error.statusCode || 500,
+        response: null,
+        message: error.message || "Internal Server Error",
+      });
+    }
+  }
+
+  async associateDevice(request: FastifyRequest, reply: FastifyReply) {
+    try {
+      const { macAddress, restaurantCnpj } = request.body as any;
+
+      const service = new AssociateDeviceService();
+      const result = await service.execute({ macAddress, restaurantCnpj });
 
       reply.status(result.statusCode).send(result);
     } catch (error: any) {

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -36,6 +36,7 @@ export async function routes(fastify: FastifyInstance) {
   // Auth
   fastify.post("/auth/register", authController.register);
   fastify.post("/auth/login", authController.login);
+  fastify.post("/auth/associate-device", authController.associateDevice);
 
   // Restaurant - Public
   fastify.get(


### PR DESCRIPTION
## Summary
- allow devices to link to restaurants
- expose `/auth/associate-device` endpoint with validation

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b995d3c80832287599732e30795b5