### PR TITLE
Return restaurant in associate-device response

### DIFF
--- a/src/modules/auth/AssociateDeviceService.ts
+++ b/src/modules/auth/AssociateDeviceService.ts
@@ -24,7 +24,10 @@ export class AssociateDeviceService {
 
     if (existing) {
       if (existing.restaurantId === restaurant.id) {
-        return successResponse(null, "mac address already associated to this cnpj");
+        return successResponse(
+          restaurant,
+          "mac address already associated to this cnpj"
+        );
       }
 
       throw {
@@ -40,6 +43,6 @@ export class AssociateDeviceService {
       },
     });
 
-    return successResponse(null, "Device associated successfully");
+    return successResponse(restaurant, "Device associated successfully");
   }
 }


### PR DESCRIPTION
## Summary
- include restaurant object in successful device association responses

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit` (fails: Type 'number' is not assignable to type 'string')

------
https://chatgpt.com/codex/tasks/task_e_689ba9ead3d4832297a99870dc82644f