### PR TITLE
fix: allow configurable cors origin

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8,11 +8,11 @@ const app = Fastify({ logger: true })
 
 const start = async () => {
   try {
+    const allowedOrigins =
+      process.env.CORS_ORIGIN?.split(',').map((origin) => origin.trim()) || true
+
     await app.register(cors, {
-      origin: [
-        'https://preview--hub-orange-admin-panel.lovable.app',
-        'https://489d023c-83a8-40ed-adeb-0e617ea00b7e.lovableproject.com'
-      ],
+      origin: allowedOrigins,
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
       allowedHeaders: ['Content-Type', 'Authorization'],
       credentials: true


### PR DESCRIPTION
## Summary
- support configurable CORS origins via `CORS_ORIGIN` env var and default to allowing all

## Testing
- `npm test`
- `timeout 5 npm start`


------
https://chatgpt.com/codex/tasks/task_e_68a4900dc12c8322ba0d2a39714e42fd