### PR TITLE
Fix `/orders` 500 by validating query context before Prisma call

### DIFF
--- a/src/modules/order/GetOrdersController.ts
+++ b/src/modules/order/GetOrdersController.ts
@@ -8,6 +8,7 @@ type GetOrdersQuery = {
 }
 
 const validOrigins: OrderOrigin[] = ["DELIVERY", "PICKUP", "LOCAL"]
+const objectIdRegex = /^[a-fA-F0-9]{24}$/
 
 export class GetOrdersController {
   async handle(request: FastifyRequest, reply: FastifyReply) {
@@ -22,6 +23,22 @@ export class GetOrdersController {
     }
 
     const { productId, origin } = request.query as GetOrdersQuery
+
+    if (!user.restaurantId || !objectIdRegex.test(user.restaurantId)) {
+      return reply.status(401).send({
+        statusCode: 401,
+        response: null,
+        message: "Invalid user context"
+      })
+    }
+
+    if (productId && !objectIdRegex.test(productId)) {
+      return reply.status(400).send({
+        statusCode: 400,
+        response: null,
+        message: "Invalid productId filter"
+      })
+    }
 
     if (origin && !validOrigins.includes(origin)) {
       return reply.status(400).send({
@@ -45,6 +62,8 @@ export class GetOrdersController {
         response: orders
       })
     } catch (error) {
+      request.log.error({ error, productId, origin, restaurantId: user.restaurantId }, "Failed to fetch orders")
+
       return reply.status(500).send({
         statusCode: 500,
         response: null,


### PR DESCRIPTION
### Motivation

- The `GET /orders` route could surface `500 Failed to fetch orders` when malformed IDs reached Prisma (e.g., invalid `productId` query param or missing/invalid `restaurantId` in token), so pre-validate inputs and improve logs.

### Description

- Added an ObjectId regex and validate `user.restaurantId` before calling the service, returning `401 Invalid user context` on failure. 
- Validate the optional `productId` query param and return `400 Invalid productId filter` when it's not a valid ObjectId. 
- Added structured `request.log.error(...)` in the controller `catch` block to capture the error plus request context for diagnostics. 
- Changed file: `src/modules/order/GetOrdersController.ts`.

### Testing

- Ran `npx prisma generate` which completed successfully. 
- Ran `npx tsc --noEmit` which completed successfully without type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc3b7f836083229303b40f589d91b7)